### PR TITLE
Relax semver for `kariminari-grape` dependency from '1.0.0' to '~> 1.0'

### DIFF
--- a/grape-kaminari.gemspec
+++ b/grape-kaminari.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "grape"
   spec.add_runtime_dependency "kaminari"
-  spec.add_runtime_dependency "kaminari-grape", "1.0.0"
+  spec.add_runtime_dependency 'kaminari-grape', '~> 1.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I had to change this to get it to install. Seems same to do, figured I'd open a pull request